### PR TITLE
Fix clonefunction example

### DIFF
--- a/Libraries/Closures.md
+++ b/Libraries/Closures.md
@@ -180,7 +180,7 @@ end
 local ClonedFunction = clonefunction(DummyFunction)
 
 print(debug.info(ClonedFunction, "l")) -- Output: 1
-print(debug.info(ClonedFunction, "n")) -- Output: ClonedFunction
+print(debug.info(ClonedFunction, "n")) -- Output: DummyFunction
 print(ClonedFunction == DummyFunction) -- Output: false
 print(getfenv(ClonedFunction) == getfenv(DummyFunction)) -- Output: true
 ```


### PR DESCRIPTION
clonefunction result should keep the original function name, and it can't possibly be "ClonedFunction" anyways